### PR TITLE
Provider Configにオプションスキーマバージョンを追加

### DIFF
--- a/src/ORiN3.Provider.Config/ORiN3ProviderConfig.Compatibility.cs
+++ b/src/ORiN3.Provider.Config/ORiN3ProviderConfig.Compatibility.cs
@@ -1,0 +1,86 @@
+using System.Collections.Generic;
+
+namespace ORiN3.Provider.Config;
+
+public partial record ORiN3ProviderConfig
+{
+#pragma warning disable IDE1006 // Preserve the parameter names of the generated constructor for named arguments.
+    public ORiN3ProviderConfig(
+        string? ProviderPath,
+        string? Version,
+        ClassInfo[]? ClassInfos,
+        string? ProviderId,
+        string? ProviderName,
+        string? Secret,
+        string? Author,
+        Dictionary<string, string>? Comment,
+        Script[]? Scripts,
+        int? ReadingFileBufferSize,
+        Dictionary<string, string>? Manual,
+        Dictionary<string, string>? License,
+        string? Log,
+        string? OutputLogDir,
+        int? LogByteSizePerFile,
+        int? LogFileCountLimit,
+        string? Category)
+        : this(
+            ProviderPath,
+            Version,
+            null,
+            ClassInfos,
+            ProviderId,
+            ProviderName,
+            Secret,
+            Author,
+            Comment,
+            Scripts,
+            ReadingFileBufferSize,
+            Manual,
+            License,
+            Log,
+            OutputLogDir,
+            LogByteSizePerFile,
+            LogFileCountLimit,
+            Category)
+    {
+    }
+#pragma warning restore IDE1006
+
+    public void Deconstruct(
+        out string? providerPath,
+        out string? version,
+        out ClassInfo[]? classInfos,
+        out string? providerId,
+        out string? providerName,
+        out string? secret,
+        out string? author,
+        out Dictionary<string, string>? comment,
+        out Script[]? scripts,
+        out int? readingFileBufferSize,
+        out Dictionary<string, string>? manual,
+        out Dictionary<string, string>? license,
+        out string? log,
+        out string? outputLogDir,
+        out int? logByteSizePerFile,
+        out int? logFileCountLimit,
+        out string? category)
+    {
+        providerPath = ProviderPath;
+        version = Version;
+        classInfos = ClassInfos;
+        providerId = ProviderId;
+        providerName = ProviderName;
+        secret = Secret;
+        author = Author;
+        comment = Comment;
+        scripts = Scripts;
+        readingFileBufferSize = ReadingFileBufferSize;
+        manual = Manual;
+        license = License;
+        log = Log;
+        outputLogDir = OutputLogDir;
+        logByteSizePerFile = LogByteSizePerFile;
+        logFileCountLimit = LogFileCountLimit;
+        category = Category;
+    }
+}

--- a/src/ORiN3.Provider.Config/ORiN3ProviderConfig.Compatibility.cs
+++ b/src/ORiN3.Provider.Config/ORiN3ProviderConfig.Compatibility.cs
@@ -45,42 +45,4 @@ public partial record ORiN3ProviderConfig
     {
     }
 #pragma warning restore IDE1006
-
-    public void Deconstruct(
-        out string? providerPath,
-        out string? version,
-        out ClassInfo[]? classInfos,
-        out string? providerId,
-        out string? providerName,
-        out string? secret,
-        out string? author,
-        out Dictionary<string, string>? comment,
-        out Script[]? scripts,
-        out int? readingFileBufferSize,
-        out Dictionary<string, string>? manual,
-        out Dictionary<string, string>? license,
-        out string? log,
-        out string? outputLogDir,
-        out int? logByteSizePerFile,
-        out int? logFileCountLimit,
-        out string? category)
-    {
-        providerPath = ProviderPath;
-        version = Version;
-        classInfos = ClassInfos;
-        providerId = ProviderId;
-        providerName = ProviderName;
-        secret = Secret;
-        author = Author;
-        comment = Comment;
-        scripts = Scripts;
-        readingFileBufferSize = ReadingFileBufferSize;
-        manual = Manual;
-        license = License;
-        log = Log;
-        outputLogDir = OutputLogDir;
-        logByteSizePerFile = LogByteSizePerFile;
-        logFileCountLimit = LogFileCountLimit;
-        category = Category;
-    }
 }

--- a/src/ORiN3.Provider.Config/ORiN3ProviderConfig.cs
+++ b/src/ORiN3.Provider.Config/ORiN3ProviderConfig.cs
@@ -28,9 +28,6 @@ public partial record ORiN3ProviderConfig
     string? Category
 )
 {
-    private const string DefaultOptionSchemaVersion = "1.0.0";
-    private const string OptionSchemaVersionKey = "@Version";
-
     [JsonIgnore]
     internal DirectoryInfo? BaseDirectory { get; set; }
 
@@ -69,7 +66,7 @@ public partial record ORiN3ProviderConfig
     public string ActualProviderName => ProviderName ?? AssemblyName;
 
     [JsonIgnore]
-    public string ActualOptionSchemaVersion => OptionSchemaVersion ?? DefaultOptionSchemaVersion;
+    public string ActualOptionSchemaVersion => OptionSchemaVersion ?? "1.0.0";
 
     [JsonIgnore]
     public string SecretKey => Secret ?? UniqueId;
@@ -167,11 +164,11 @@ public partial record ORiN3ProviderConfig
     {
         var dict = new Dictionary<string, object?>
             {
-                { OptionSchemaVersionKey, ActualOptionSchemaVersion }
+                { "@Version", ActualOptionSchemaVersion }
             };
         foreach (var option in options)
         {
-            if (option.Optional || option.Name is null || option.Name == OptionSchemaVersionKey)
+            if (option.Optional || option.Name is null)
             {
                 continue;
             }

--- a/src/ORiN3.Provider.Config/ORiN3ProviderConfig.cs
+++ b/src/ORiN3.Provider.Config/ORiN3ProviderConfig.cs
@@ -5,10 +5,12 @@ using System.Text.Json.Serialization;
 
 namespace ORiN3.Provider.Config;
 
-public record ORiN3ProviderConfig
+[method: JsonConstructor]
+public partial record ORiN3ProviderConfig
 (
     string? ProviderPath,
     string? Version,
+    string? OptionSchemaVersion,
     ClassInfo[]? ClassInfos,
     string? ProviderId,
     string? ProviderName,
@@ -26,6 +28,9 @@ public record ORiN3ProviderConfig
     string? Category
 )
 {
+    private const string DefaultOptionSchemaVersion = "1.0.0";
+    private const string OptionSchemaVersionKey = "@Version";
+
     [JsonIgnore]
     internal DirectoryInfo? BaseDirectory { get; set; }
 
@@ -62,6 +67,9 @@ public record ORiN3ProviderConfig
     /// </summary>
     [JsonIgnore]
     public string ActualProviderName => ProviderName ?? AssemblyName;
+
+    [JsonIgnore]
+    public string ActualOptionSchemaVersion => OptionSchemaVersion ?? DefaultOptionSchemaVersion;
 
     [JsonIgnore]
     public string SecretKey => Secret ?? UniqueId;
@@ -126,6 +134,7 @@ public record ORiN3ProviderConfig
 
         return ProviderPath == compared.ProviderPath
             && Version == compared.Version
+            && OptionSchemaVersion == compared.OptionSchemaVersion
             && ProviderId == compared.ProviderId
             && ProviderName == compared.ProviderName
             && Author == compared.Author
@@ -158,11 +167,11 @@ public record ORiN3ProviderConfig
     {
         var dict = new Dictionary<string, object?>
             {
-                { "@Version", Version ?? string.Empty }
+                { OptionSchemaVersionKey, ActualOptionSchemaVersion }
             };
         foreach (var option in options)
         {
-            if (option.Optional || option.Name is null)
+            if (option.Optional || option.Name is null || option.Name == OptionSchemaVersionKey)
             {
                 continue;
             }

--- a/src/ORiN3.Provider.Config/ORiN3ProviderConfigMerger.cs
+++ b/src/ORiN3.Provider.Config/ORiN3ProviderConfigMerger.cs
@@ -118,7 +118,7 @@ public class ORiN3ProviderConfigMerger
         var parents = first.Parents is null && second.Parents is null ? null
             : first.Parents is null ? second.Parents
             : second.Parents is null ? first.Parents
-            : [.. first.Parents.Concat(second.Parents).Distinct()];
+            : first.Parents.Concat(second.Parents).Distinct().ToArray();
         var comments = Merge(first.Comment, second.Comment);
         var options = Merge(first.Options, second.Options);
         return new ClassInfo(

--- a/src/ORiN3.Provider.Config/ORiN3ProviderConfigMerger.cs
+++ b/src/ORiN3.Provider.Config/ORiN3ProviderConfigMerger.cs
@@ -44,6 +44,7 @@ public class ORiN3ProviderConfigMerger
 
         var providerPath = second.ProviderPath is null ? first.ProviderPath : second.ProviderPath;
         var version = second.Version is null ? first.Version : second.Version;
+        var optionSchemaVersion = second.OptionSchemaVersion is null ? first.OptionSchemaVersion : second.OptionSchemaVersion;
         var providerId = second.ProviderId is null ? first.ProviderId : second.ProviderId;
         var providerName = second.ProviderName is null ? first.ProviderName : second.ProviderName;
         var secret = second.Secret is null ? first.Secret : second.Secret;
@@ -61,6 +62,7 @@ public class ORiN3ProviderConfigMerger
         return new ORiN3ProviderConfig(
             providerPath,
             version,
+            optionSchemaVersion,
             classInfos,
             providerId,
             providerName,
@@ -116,7 +118,7 @@ public class ORiN3ProviderConfigMerger
         var parents = first.Parents is null && second.Parents is null ? null
             : first.Parents is null ? second.Parents
             : second.Parents is null ? first.Parents
-            : first.Parents.Concat(second.Parents).Distinct().ToArray();
+            : [.. first.Parents.Concat(second.Parents).Distinct()];
         var comments = Merge(first.Comment, second.Comment);
         var options = Merge(first.Options, second.Options);
         return new ClassInfo(

--- a/test/ORiN3.Provider.Config.Test/TestByDeveloper/MergeTest.cs
+++ b/test/ORiN3.Provider.Config.Test/TestByDeveloper/MergeTest.cs
@@ -801,6 +801,18 @@ public class MergeTest
         Assert.Equal(merger.Author, first.Author);
     }
 
+    [Fact(DisplayName = "Check that OptionSchemaVersion is merged")]
+    [Trait("Category", nameof(ORiN3ProviderConfigMerger))]
+    public async Task MergeTest11Async()
+    {
+        var first = await ORiN3ProviderConfigReader.ReadAsync("""{ "optionSchemaVersion": "1.0.0" }""");
+        var second = await ORiN3ProviderConfigReader.ReadAsync("""{ "optionSchemaVersion": "2.0.0" }""");
+        var withoutOptionSchemaVersion = await ORiN3ProviderConfigReader.ReadAsync("{}");
+
+        Assert.Equal("2.0.0", ORiN3ProviderConfigMerger.Merge(first, second).OptionSchemaVersion);
+        Assert.Equal("1.0.0", ORiN3ProviderConfigMerger.Merge(first, withoutOptionSchemaVersion).OptionSchemaVersion);
+    }
+
     [SkippableFact(DisplayName = "Check that if one classinfos is null, substitute another classinfos")]
     [Trait("Category", nameof(ORiN3ProviderConfigMerger))]
     public async Task MergeTest04Async()

--- a/test/ORiN3.Provider.Config.Test/TestByDeveloper/ProviderConfigTest.cs
+++ b/test/ORiN3.Provider.Config.Test/TestByDeveloper/ProviderConfigTest.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.Runtime.InteropServices;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -147,5 +148,41 @@ public class ProviderConfigTest
         file.Attributes &= ~FileAttributes.Hidden;
         var orin3ProviderConfig = await ORiN3ProviderConfigReader.ReadAsync(file);
         Assert.Equal("Hoge.dll", orin3ProviderConfig.ActualProviderName);
+    }
+
+    [Fact(DisplayName = "Check that ActualOptionSchemaVersion returns the default version if OptionSchemaVersion does not exist")]
+    [Trait("Category", nameof(ProviderConfigTest))]
+    public async Task ProviderConfigTest12()
+    {
+        var orin3ProviderConfig = await ORiN3ProviderConfigReader.ReadAsync("{}");
+
+        Assert.Equal("1.0.0", orin3ProviderConfig.ActualOptionSchemaVersion);
+    }
+
+    [Fact(DisplayName = "Check that GetDefaultOptions uses OptionSchemaVersion")]
+    [Trait("Category", nameof(ProviderConfigTest))]
+    public async Task ProviderConfigTest13()
+    {
+        var configData = """
+            {
+                "version": "2.0.0",
+                "optionSchemaVersion": "1.1.0"
+            }
+            """;
+        var orin3ProviderConfig = await ORiN3ProviderConfigReader.ReadAsync(configData);
+        var options = orin3ProviderConfig.GetDefaultOptions([new("@Version", null, "9.9.9", false, null)]);
+        using var optionsDocument = JsonDocument.Parse(options);
+
+        Assert.Equal("1.1.0", optionsDocument.RootElement.GetProperty("@Version").GetString());
+    }
+
+    [Fact(DisplayName = "Check that EqualsSpecifically compares OptionSchemaVersion")]
+    [Trait("Category", nameof(ProviderConfigTest))]
+    public async Task ProviderConfigTest14()
+    {
+        var first = await ORiN3ProviderConfigReader.ReadAsync("{}");
+        var second = first with { OptionSchemaVersion = "1.0.0" };
+
+        Assert.False(first.EqualsSpecifically(second));
     }
 }

--- a/test/ORiN3.Provider.Config.Test/TestByDeveloper/ProviderConfigTest.cs
+++ b/test/ORiN3.Provider.Config.Test/TestByDeveloper/ProviderConfigTest.cs
@@ -165,15 +165,15 @@ public class ProviderConfigTest
     {
         var configData = """
             {
-                "version": "2.0.0",
-                "optionSchemaVersion": "1.1.0"
+                "version": "1.0.0",
+                "optionSchemaVersion": "2.0.0"
             }
             """;
         var orin3ProviderConfig = await ORiN3ProviderConfigReader.ReadAsync(configData);
-        var options = orin3ProviderConfig.GetDefaultOptions([new("@Version", null, "9.9.9", false, null)]);
+        var options = orin3ProviderConfig.GetDefaultOptions([]);
         using var optionsDocument = JsonDocument.Parse(options);
 
-        Assert.Equal("1.1.0", optionsDocument.RootElement.GetProperty("@Version").GetString());
+        Assert.Equal("2.0.0", optionsDocument.RootElement.GetProperty("@Version").GetString());
     }
 
     [Fact(DisplayName = "Check that EqualsSpecifically compares OptionSchemaVersion")]


### PR DESCRIPTION
## 概要

Providerのアプリケーションバージョンとオプションスキーマバージョンを分離するため、`ORiN3ProviderConfig`に任意の`OptionSchemaVersion`を追加します。

`OptionSchemaVersion`が未指定の場合、実効値は`1.0.0`になります。`GetDefaultOptions()`が生成する`@Version`には、Providerの`Version`ではなく、この実効オプションスキーマバージョンを設定します。

## 変更内容

- `ORiN3ProviderConfig`に`OptionSchemaVersion`と`ActualOptionSchemaVersion`を追加
- 未指定時の実効オプションスキーマバージョンを`1.0.0`に設定
- `GetDefaultOptions()`の`@Version`を実効オプションスキーマバージョンから生成
- 呼び出し互換性のため、既存17引数コンストラクターを維持
- `EqualsSpecifically()`で`OptionSchemaVersion`を比較
- Provider Configのマージ時に`OptionSchemaVersion`を引き継ぐ

## 影響

`GetDefaultOptions()`が生成する`@Version`は、Providerのアプリケーションバージョンからオプションスキーマバージョンへ変わります。既存のProvider Configは`optionSchemaVersion`を省略でき、省略時は`1.0.0`として扱われます。

## 確認内容

- `dotnet build ORiN3.sln --no-restore`
  - 警告0、エラー0
- `dotnet test ORiN3.sln --no-build --no-restore`
  - `ORiN3.Provider.Config.Test`: 142件成功、14件スキップ
  - `Message.ORiN3.Provider.Test`: 1399件成功
- C#クリーンアップスクリプト実行済み
- 既存17引数コンストラクターと新しい18引数コンストラクターの両シグネチャが生成されることを確認済み